### PR TITLE
Force compilation of linkedlistapi in elina

### DIFF
--- a/optoctagons/Makefile
+++ b/optoctagons/Makefile
@@ -50,6 +50,7 @@ AINST = liboptoct.a
 OPTOCTH = opt_oct.h opt_oct_internal.h opt_oct_hmat.h $(CLOSUREH)
 
 
+.PHONY: linkedlistapi
 
 all : linkedlistapi liboptoct.so liboptoct.a 
 	@echo "-- Compiled optoct with flags $(IS_VECTOR) $(IS_SSE) ... "


### PR DESCRIPTION
Just like 860f977; prevents spurious `make: 'linkedlistapi' is up to date`.

I believe it's needed here in order to work on a linux guest machine with project folder shared with a mac host.